### PR TITLE
Re-enable config based workflows

### DIFF
--- a/perf.py
+++ b/perf.py
@@ -125,7 +125,7 @@ class TimeCalculation:
         self.tot_mem            = 0
         self.tot_time           = 0
         self.debug              = False #############################
-        self.validating_GEMM    = True
+        self.validating_GEMM    = False
     
     def updateParams(self, debug, m, n, k, t, kp1, kp2, dp, lp, gemm,
                       batch_size, hidden_dim, seq_len, vocab_size, num_layer):


### PR DESCRIPTION
validating_gemm flag == True means that only IMEC-style scripts can run without a spurious error.
This fixes that.
